### PR TITLE
Fixes for CRAN notification of new issues in R-devel

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^cran-comments\.md$
+^revdep$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: Functions to perform Bayesian inference on absorption time data for
              <https://www.louisaslett.com/PhD_Thesis.pdf> are provided.
 URL: https://www.louisaslett.com/PhaseType/, https://github.com/louisaslett/PhaseType
 BugReports: https://github.com/louisaslett/PhaseType/issues
-Version: 0.2.1
+Version: 0.3.0
 Maintainer: Louis Aslett <louis.aslett@durham.ac.uk>
 Authors@R: c(person("Louis", "Aslett", email = "louis.aslett@durham.ac.uk",
                     role = c("aut", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+PhaseType 0.3.0
+===============
+
+ * Fix requested by CRAN to change Calloc and Free C calls to use R_ versions,
+   so that STRICT_R_HEADERS=1 compiles ok (to be default from R 4.5.0)
+
 PhaseType 0.2.0
 ===============
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ install.packages("PhaseType")
 
 ## Install development version (not recommended)
 
-Installing directly from [GitHub](https://github.com) is not supported by the
-`install.packages` command. You could use the
-[devtools](https://CRAN.R-project.org/package=devtools) package
-to install the development version if desired.
+You can get the very latest version from R-universe:
+
+```r
+install.packages("PhaseType", repos = c("https://louisaslett.r-universe.dev", "https://cloud.r-project.org"))
+```
+
+Installing directly from [GitHub](https://github.com) is not supported by the `install.packages` command, but if you wish to compile from source then you could use the [devtools](https://CRAN.R-project.org/package=devtools) package:
 
 ```r
 install.packages("remotes")
@@ -77,7 +80,7 @@ so historic source can be downloaded from there.
 
 ## Citation
 
-If you use this software, please cite the following:
+If you use this software, please use the following citation:
 
 Aslett, L. J. M. (2012), MCMC for Inference on Phase-type and Masked System Lifetime Models, PhD thesis, Trinity College Dublin.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PhaseType R package :package:
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![license](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
-[![metacran version](http://www.r-pkg.org/badges/version/PhaseType)](https://CRAN.R-project.org/package=PhaseType)
-[![metacran downloads](http://cranlogs.r-pkg.org/badges/PhaseType?color=brightgreen)](https://CRAN.R-project.org/package=PhaseType)
-<!--[CRAN check result](https://cran.r-project.org/web/checks/check_results_PhaseType.html)-->
+[![license](https://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](https://www.gnu.org/licenses/gpl-2.0.html)
+[![metacran version](https://www.r-pkg.org/badges/version/PhaseType)](https://cran.r-project.org/package=PhaseType)
+[![metacran downloads](https://cranlogs.r-pkg.org/badges/grand-total/PhaseType)](https://cran.r-project.org/package=PhaseType)
+[![PhaseType status badge](https://louisaslett.r-universe.dev/badges/PhaseType)](https://louisaslett.r-universe.dev/PhaseType)
 
 This is a package for working with Phase-type (PHT) distributions in the R programming language.
 The entire of the MCMC portion of the code has been written in optimised C for higher performance and very low memory use, whilst being easy to call from wrapper R functions.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,12 @@
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+* This release is a fix requested by Kurt Hornik for when compilation with STRICT_R_HEADERS is set to 1, which is due to become default in R 4.5.0.
+
+## revdepcheck results
+
+We checked 1 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages

--- a/revdep/.gitignore
+++ b/revdep/.gitignore
@@ -1,0 +1,7 @@
+checks
+library
+checks.noindex
+library.noindex
+cloud.noindex
+data.sqlite
+*.html

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,0 +1,24 @@
+# Platform
+
+|field    |value                                                                                               |
+|:--------|:---------------------------------------------------------------------------------------------------|
+|version  |R version 4.4.1 (2024-06-14)                                                                        |
+|os       |macOS Sonoma 14.6.1                                                                                 |
+|system   |aarch64, darwin20                                                                                   |
+|ui       |RStudio                                                                                             |
+|language |(EN)                                                                                                |
+|collate  |en_US.UTF-8                                                                                         |
+|ctype    |en_US.UTF-8                                                                                         |
+|tz       |Europe/London                                                                                       |
+|date     |2024-09-14                                                                                          |
+|rstudio  |2024.04.2+764 Chocolate Cosmos (desktop)                                                            |
+|pandoc   |3.1.11 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown) |
+
+# Dependencies
+
+|package   |old   |new   |Δ  |
+|:---------|:-----|:-----|:--|
+|PhaseType |0.2.1 |0.3.0 |*  |
+
+# Revdeps
+

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,0 +1,7 @@
+## revdepcheck results
+
+We checked 1 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages
+

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,0 +1,1 @@
+*Wow, no problems at all. :)*

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -1,0 +1,1 @@
+*Wow, no problems at all. :)*

--- a/src/utility.c
+++ b/src/utility.c
@@ -20,10 +20,10 @@ void LJMA_LAPACKspace(int *n) {
 	F77_CALL(dgetri)(n, NULL, n, NULL, &work, &lwork, &info);
 	if((int) work > LJMA_LAPACK_lwork) LJMA_LAPACK_lwork = (int) work;
 	//LJMA_LAPACK_work = (double *) R_alloc(LJMA_LAPACK_lwork, sizeof(double));
-	LJMA_LAPACK_work = (double *) Calloc(LJMA_LAPACK_lwork, double);
+	LJMA_LAPACK_work = (double *) R_Calloc(LJMA_LAPACK_lwork, double);
 }
 void LJMA_LAPACKspaceFree(void) {
-	Free(LJMA_LAPACK_work);
+	R_Free(LJMA_LAPACK_work);
 }
 
 


### PR DESCRIPTION
This addresses the CRAN notification received below, as well as some other small issues.

> Dear maintainer,
> 
> Please see the problems shown on
> <https://cran.r-project.org/web/checks/check_results_PhaseType.html>
> 
> Specifically, please see the *Strict* additional issue.
> 
> Compilation fails with _R_USE_STRICT_R_HEADERS_=true, which defines
> STRICT_R_HEADERS to 1 which removes
> 
> - the legacy definition of PI (use POSIX's M_PI, available in R fer ever).
> - the RS.h declarations for Calloc, Realloc, Free (use R_ forms i
>   available since R 3.4.0).
> 
> The aim is to clean the namespace: in particular having a definition
> for Free has conflicted with some packages' C++ code.
> 
> It is planned that STRICT_R_HEADERS=1 will become the default for 4.5.0,
> for which it would be good if all CRAN packages, and in particular the
> ones with strong reverse dependencies, compile/install ok with the new
> default.
> 
> Your package is among the ones with strong reverse dependencies which
> need updating.  We would thus really appreciate if you could provide a
> new version of your package as soon as possible which checks ok with
> STRICT_R_HEADERS=1.
> 
> You can verify that your package checks ok with STRICT_R_HEADERS=1 via R
> CMD check --as-cran using a current version of R-devel.
> 
> Please correct before 2024-10-04 to safely retain your package on CRAN.
